### PR TITLE
feat: make all AI model names and Gemini base URL configurable via env vars

### DIFF
--- a/src/tools/eyes/providers/zhipuai-vision-provider.ts
+++ b/src/tools/eyes/providers/zhipuai-vision-provider.ts
@@ -30,7 +30,7 @@ export async function analyzeWithZhipuAI(
   options: ZhipuAIVisionOptions
 ): Promise<{ analysis: string; metadata: { processing_time_ms: number } }> {
   const startTime = Date.now();
-  const { source, focus, detail, model = "glm-4.6v-flash", config } = options;
+  const { source, focus, detail, model = options.config?.zhipuai?.visionModel || "glm-4.6v-flash", config } = options;
 
   const client = new ZhipuAIClient(config);
 

--- a/src/tools/eyes/utils/gemini-client.ts
+++ b/src/tools/eyes/utils/gemini-client.ts
@@ -139,7 +139,7 @@ export class GeminiClient {
         );
       }
 
-      this.provider = new GoogleAIStudioProvider(config.gemini.apiKey);
+      this.provider = new GoogleAIStudioProvider(config.gemini.apiKey, config.gemini.baseUrl);
       logger.info("Using Google AI Studio");
     }
 
@@ -233,7 +233,8 @@ export class GeminiClient {
         body: JSON.stringify(requestBody)
       });
     } else {
-      const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent`;
+      const geminiBaseUrl = this.config.gemini.baseUrl || "https://generativelanguage.googleapis.com/v1beta";
+      const url = `${geminiBaseUrl}/models/${modelName}:generateContent`;
 
       if (!this.config.gemini.apiKey) {
         throw new APIError(
@@ -1540,7 +1541,7 @@ Extract as much metadata as possible from the document properties and content.`;
    * Get speech generation model for text-to-speech
    */
   getSpeechModel(modelName?: string): GenerativeModel {
-    const speechModelName = modelName || "gemini-2.5-flash-preview-tts";
+    const speechModelName = modelName || this.config.gemini.ttsModel || "gemini-2.5-flash-preview-tts";
 
     // Gemini 3 series: omit temperature per Google migration guide
     const generationConfig = this.isGemini3Series(speechModelName)
@@ -1569,7 +1570,7 @@ Extract as much metadata as possible from the document properties and content.`;
     try {
       const {
         voice = "Zephyr",
-        model = "gemini-2.5-flash-preview-tts",
+        model = this.config.gemini.ttsModel || "gemini-2.5-flash-preview-tts",
         language = "en-US",
         stylePrompt
       } = options;
@@ -1632,7 +1633,8 @@ Extract as much metadata as possible from the document properties and content.`;
         });
       } else {
         // Google AI Studio mode - use API key authentication
-        const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
+        const geminiBaseUrl = this.config.gemini.baseUrl || "https://generativelanguage.googleapis.com/v1beta";
+        const url = `${geminiBaseUrl}/models/${model}:generateContent`;
 
         if (!this.config.gemini.apiKey) {
           throw new APIError(
@@ -1804,7 +1806,7 @@ Extract as much metadata as possible from the document properties and content.`;
    * Get video generation model for Veo 3.0
    */
   getVideoGenerationModel(modelName?: string): GenerativeModel {
-    const videoModelName = modelName || "veo-3.0-generate-001";
+    const videoModelName = modelName || this.config.gemini.videoModel || "veo-3.0-generate-001";
 
     // Gemini 3 series: omit temperature per Google migration guide
     const generationConfig = this.isGemini3Series(videoModelName)
@@ -1845,7 +1847,7 @@ Extract as much metadata as possible from the document properties and content.`;
   ): Promise<{ videoData: string; metadata: any; operationId: string }> {
     try {
       const {
-        model = "veo-3.0-generate-001",
+        model = this.config.gemini.videoModel || "veo-3.0-generate-001",
         duration = "4s",
         aspectRatio = "16:9",
         fps = 24,

--- a/src/tools/eyes/utils/providers/google-ai-studio-provider.ts
+++ b/src/tools/eyes/utils/providers/google-ai-studio-provider.ts
@@ -10,12 +10,16 @@ import { logger } from "@/utils/logger.js";
 export class GoogleAIStudioProvider implements IGeminiProvider {
   private genAI: GoogleGenerativeAI;
 
-  constructor(apiKey: string) {
+  constructor(apiKey: string, baseUrl?: string) {
     if (!apiKey) {
       throw new APIError("Google Gemini API key is required for Google AI Studio provider");
     }
-    this.genAI = new GoogleGenerativeAI(apiKey);
-    logger.info("Initialized Google AI Studio provider");
+    this.genAI = new GoogleGenerativeAI(apiKey, baseUrl ? { baseUrl } : undefined);
+    if (baseUrl) {
+      logger.info(`Initialized Google AI Studio provider with custom base URL: ${baseUrl}`);
+    } else {
+      logger.info("Initialized Google AI Studio provider");
+    }
   }
 
   getGenerativeModel(params: {

--- a/src/tools/hands/processors/image-generator.ts
+++ b/src/tools/hands/processors/image-generator.ts
@@ -18,6 +18,7 @@ export async function generateImage(
   if (provider === "zhipuai" && config && ZhipuAIClient.isConfigured(config)) {
     return generateWithZhipuAI({
       prompt: options.prompt,
+      model: options.model || config.zhipuai?.imageModel,
       aspectRatio: options.aspectRatio,
       outputFormat: options.outputFormat,
       uploadToR2: options.uploadToR2,

--- a/src/tools/hands/providers/elevenlabs-music-provider.ts
+++ b/src/tools/hands/providers/elevenlabs-music-provider.ts
@@ -52,7 +52,7 @@ export async function generateElevenLabsMusic(
   const body: Record<string, unknown> = {
     prompt,
     music_length_ms,
-    model_id: "music_v1",
+    model_id: config.elevenlabs?.musicModel || "music_v1",
     force_instrumental,
   };
 

--- a/src/tools/hands/providers/elevenlabs-sfx-provider.ts
+++ b/src/tools/hands/providers/elevenlabs-sfx-provider.ts
@@ -49,7 +49,7 @@ export async function generateElevenLabsSfx(
 
   const body: Record<string, unknown> = {
     text,
-    model_id: "eleven_text_to_sound_v2",
+    model_id: config.elevenlabs?.sfxModel || "eleven_text_to_sound_v2",
     prompt_influence,
     loop,
   };

--- a/src/tools/hands/providers/minimax-video-provider.ts
+++ b/src/tools/hands/providers/minimax-video-provider.ts
@@ -19,7 +19,7 @@ export interface MinimaxVideoOptions {
   config: Config;
 }
 
-const DEFAULT_MODEL = "MiniMax-Hailuo-2.3";
+const DEFAULT_MODEL = process.env.MINIMAX_VIDEO_MODEL || "MiniMax-Hailuo-2.3";
 const POLL_INTERVAL_MS = 10_000;
 const MAX_POLL_TIME_MS = 900_000; // 15 minutes
 

--- a/src/tools/hands/providers/zhipuai-image-provider.ts
+++ b/src/tools/hands/providers/zhipuai-image-provider.ts
@@ -46,7 +46,7 @@ export async function generateWithZhipuAI(
   options: ZhipuAIImageOptions & { aspectRatio?: string; outputFormat?: string; uploadToR2?: boolean }
 ): Promise<ImageGenerationResult> {
   const startTime = Date.now();
-  const { prompt, model = "glm-image", config, aspectRatio, outputFormat, uploadToR2 } = options;
+  const { prompt, model = process.env.ZHIPUAI_IMAGE_MODEL || "glm-image", config, aspectRatio, outputFormat, uploadToR2 } = options;
 
   const client = new ZhipuAIClient(config);
 

--- a/src/tools/hands/providers/zhipuai-video-provider.ts
+++ b/src/tools/hands/providers/zhipuai-video-provider.ts
@@ -72,7 +72,7 @@ export async function generateZhipuAIVideo(
 
   const {
     prompt,
-    model = "cogvideox-3",
+    model = options.config?.zhipuai?.videoModel || "cogvideox-3",
     quality = "quality",
     withAudio = false,
     fps = 30,

--- a/src/tools/mouth/providers/elevenlabs-speech-provider.ts
+++ b/src/tools/mouth/providers/elevenlabs-speech-provider.ts
@@ -23,7 +23,7 @@ export interface ElevenLabsSpeechOptions {
 
 /** Default voice: Rachel */
 const DEFAULT_VOICE_ID = "21m00Tcm4TlvDq8ikWAM";
-const DEFAULT_MODEL = "eleven_multilingual_v2";
+const DEFAULT_MODEL = process.env.ELEVENLABS_SPEECH_MODEL || "eleven_multilingual_v2";
 
 /**
  * Curated voice name -> ID mapping for convenience.

--- a/src/tools/mouth/providers/minimax-speech-provider.ts
+++ b/src/tools/mouth/providers/minimax-speech-provider.ts
@@ -20,7 +20,7 @@ export interface MinimaxSpeechOptions {
 }
 
 const DEFAULT_MINIMAX_VOICE = "English_Graceful_Lady";
-const DEFAULT_MINIMAX_MODEL = "speech-2.6-hd";
+const DEFAULT_MINIMAX_MODEL = process.env.MINIMAX_SPEECH_MODEL || "speech-2.6-hd";
 
 export async function generateMinimaxSpeech(
   options: MinimaxSpeechOptions

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,6 +5,10 @@ const ConfigSchema = z.object({
     apiKey: z.string().optional(), // Optional since Vertex AI doesn't need it
     model: z.string().default("gemini-2.5-flash"),
     imageModel: z.string().default("gemini-2.5-flash-image"),
+    ttsModel: z.string().default("gemini-2.5-flash-preview-tts"),
+    videoModel: z.string().default("veo-3.0-generate-001"),
+    // Custom base URL for proxies (e.g. LiteLLM, Yescale, OpenRouter)
+    baseUrl: z.string().optional(),
     // Vertex AI configuration
     useVertexAI: z.boolean().default(false),
     vertexProjectId: z.string().optional(),
@@ -53,15 +57,22 @@ const ConfigSchema = z.object({
   minimax: z.object({
     apiKey: z.string().optional(),
     apiHost: z.string().default("https://api.minimax.io"),
+    videoModel: z.string().default("MiniMax-Hailuo-2.3"),
+    speechModel: z.string().default("speech-2.6-hd"),
   }).optional(),
   zhipuai: z.object({
     apiKey: z.string().optional(),
     apiHost: z.string().default("https://api.z.ai/api/paas/v4"),
     imageModel: z.string().default("glm-image"),
+    visionModel: z.string().default("glm-4.6v-flash"),
+    videoModel: z.string().default("cogvideox-3"),
   }).optional(),
   elevenlabs: z.object({
     apiKey: z.string().optional(),
     apiHost: z.string().default("https://api.elevenlabs.io"),
+    speechModel: z.string().default("eleven_multilingual_v2"),
+    musicModel: z.string().default("music_v1"),
+    sfxModel: z.string().default("eleven_text_to_sound_v2"),
   }).optional(),
   providers: z.object({
     speech: z.enum(["gemini", "minimax", "elevenlabs"]).default("gemini"),
@@ -120,6 +131,9 @@ export function loadConfig(): Config {
       apiKey: process.env.GOOGLE_GEMINI_API_KEY || "",
       model: process.env.GOOGLE_GEMINI_MODEL || "gemini-2.5-flash",
       imageModel: process.env.GOOGLE_GEMINI_IMAGE_MODEL || "gemini-2.5-flash-image",
+      ttsModel: process.env.GOOGLE_GEMINI_TTS_MODEL || "gemini-2.5-flash-preview-tts",
+      videoModel: process.env.GOOGLE_GEMINI_VIDEO_MODEL || "veo-3.0-generate-001",
+      baseUrl: process.env.GOOGLE_GEMINI_BASE_URL,
       // Vertex AI config
       useVertexAI,
       vertexProjectId: process.env.VERTEX_PROJECT_ID,
@@ -168,15 +182,22 @@ export function loadConfig(): Config {
     minimax: {
       apiKey: process.env.MINIMAX_API_KEY,
       apiHost: process.env.MINIMAX_API_HOST || "https://api.minimax.io",
+      videoModel: process.env.MINIMAX_VIDEO_MODEL || "MiniMax-Hailuo-2.3",
+      speechModel: process.env.MINIMAX_SPEECH_MODEL || "speech-2.6-hd",
     },
     zhipuai: {
       apiKey: process.env.ZHIPUAI_API_KEY,
       apiHost: process.env.ZHIPUAI_API_HOST || "https://api.z.ai/api/paas/v4",
       imageModel: process.env.ZHIPUAI_IMAGE_MODEL || "glm-image",
+      visionModel: process.env.ZHIPUAI_VISION_MODEL || "glm-4.6v-flash",
+      videoModel: process.env.ZHIPUAI_VIDEO_MODEL || "cogvideox-3",
     },
     elevenlabs: {
       apiKey: process.env.ELEVENLABS_API_KEY,
       apiHost: process.env.ELEVENLABS_API_HOST || "https://api.elevenlabs.io",
+      speechModel: process.env.ELEVENLABS_SPEECH_MODEL || "eleven_multilingual_v2",
+      musicModel: process.env.ELEVENLABS_MUSIC_MODEL || "music_v1",
+      sfxModel: process.env.ELEVENLABS_SFX_MODEL || "eleven_text_to_sound_v2",
     },
     providers: {
       speech: (process.env.SPEECH_PROVIDER as any) || "gemini",

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -57,6 +57,7 @@ const ConfigSchema = z.object({
   zhipuai: z.object({
     apiKey: z.string().optional(),
     apiHost: z.string().default("https://api.z.ai/api/paas/v4"),
+    imageModel: z.string().default("glm-image"),
   }).optional(),
   elevenlabs: z.object({
     apiKey: z.string().optional(),
@@ -171,6 +172,7 @@ export function loadConfig(): Config {
     zhipuai: {
       apiKey: process.env.ZHIPUAI_API_KEY,
       apiHost: process.env.ZHIPUAI_API_HOST || "https://api.z.ai/api/paas/v4",
+      imageModel: process.env.ZHIPUAI_IMAGE_MODEL || "glm-image",
     },
     elevenlabs: {
       apiKey: process.env.ELEVENLABS_API_KEY,


### PR DESCRIPTION
## Problem

human-mcp hardcodes AI model names and API endpoint URLs across providers. This makes it impossible to:
- Route Gemini requests through an OpenAI-compatible proxy (Yescale, OpenRouter, LiteLLM)
- Swap ZhipuAI vision/video models without changing source code
- Override Minimax or ElevenLabs default models per deployment

## Solution

Expose every hardcoded model name and the Gemini base URL as configurable env vars, with original values kept as defaults so existing deployments are unaffected.

## Environment Variables Added

### Gemini
| Variable | Default | Description |
|----------|---------|-------------|
| `GOOGLE_GEMINI_BASE_URL` | `https://generativelanguage.googleapis.com/v1beta` | Override base URL for proxy routing (Yescale, OpenRouter, LiteLLM) |
| `GOOGLE_GEMINI_TTS_MODEL` | `gemini-2.5-flash-preview-tts` | TTS model name |
| `GOOGLE_GEMINI_VIDEO_MODEL` | `veo-3.0-generate-001` | Video generation model |

### ZhipuAI
| Variable | Default | Description |
|----------|---------|-------------|
| `ZHIPUAI_IMAGE_MODEL` | `glm-image` | Image generation model _(from original PR)_ |
| `ZHIPUAI_VISION_MODEL` | `glm-4.6v-flash` | Vision/analysis model |
| `ZHIPUAI_VIDEO_MODEL` | `cogvideox-3` | Video generation model |

### Minimax
| Variable | Default | Description |
|----------|---------|-------------|
| `MINIMAX_VIDEO_MODEL` | `MiniMax-Hailuo-2.3` | Video generation model |
| `MINIMAX_SPEECH_MODEL` | `speech-2.6-hd` | Speech/TTS model |

### ElevenLabs
| Variable | Default | Description |
|----------|---------|-------------|
| `ELEVENLABS_SPEECH_MODEL` | `eleven_multilingual_v2` | Speech model |
| `ELEVENLABS_MUSIC_MODEL` | `music_v1` | Music generation model |
| `ELEVENLABS_SFX_MODEL` | `eleven_text_to_sound_v2` | Sound effects model |

## Files Changed

- `src/utils/config.ts` — schema + `loadConfig()` for all new env vars
- `src/tools/eyes/utils/providers/google-ai-studio-provider.ts` — accept `baseUrl` in constructor, pass to `GoogleGenerativeAI` SDK
- `src/tools/eyes/utils/gemini-client.ts` — wire `baseUrl` to provider; replace 2 hardcoded googleapis.com URLs; use config for TTS + video model defaults
- `src/tools/eyes/providers/zhipuai-vision-provider.ts` — use `config.zhipuai.visionModel`
- `src/tools/hands/providers/zhipuai-video-provider.ts` — use `config.zhipuai.videoModel`
- `src/tools/hands/providers/minimax-video-provider.ts` — use `MINIMAX_VIDEO_MODEL` env var
- `src/tools/mouth/providers/minimax-speech-provider.ts` — use `MINIMAX_SPEECH_MODEL` env var
- `src/tools/mouth/providers/elevenlabs-speech-provider.ts` — use `ELEVENLABS_SPEECH_MODEL` env var
- `src/tools/hands/providers/elevenlabs-music-provider.ts` — use `config.elevenlabs.musicModel`
- `src/tools/hands/providers/elevenlabs-sfx-provider.ts` — use `config.elevenlabs.sfxModel`

## Use Case: Yescale / OpenRouter Proxy

```bash
# Route all Gemini raw fetch calls through Yescale
GOOGLE_GEMINI_BASE_URL=https://api.yescale.io/v1

# Or use ZhipuAI path with Yescale-hosted model
ZHIPUAI_API_HOST=https://api.yescale.io/v1
ZHIPUAI_IMAGE_MODEL=imagen4-fast
IMAGE_PROVIDER=zhipuai
```

## Backwards Compatible

All defaults match the original hardcoded values. Zero behavior change for existing deployments.