### PR TITLE
fix: pin onnxruntime-node to ship darwin/x64 bindings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,10 @@ jobs:
         run: bun install --frozen-lockfile
         timeout-minutes: 5
 
+      - name: Verify ONNX Runtime native bindings
+        run: bun run verify:native
+        timeout-minutes: 1
+
       - name: Run type check
         run: bun run typecheck
         timeout-minutes: 3

--- a/README.md
+++ b/README.md
@@ -736,6 +736,10 @@ cd /path/to/human-mcp && bun run inspector
    - Use `npx` instead of global installation if needed
    - Verify API key has necessary permissions
 
+5. **macOS Intel / `darwin/x64`: crash on startup (`onnxruntime_binding.node` missing)**
+   - Background removal (`rmbg`) depends on `onnxruntime-node`. Some `onnxruntime-node` 1.24.x releases did not ship `darwin/x64` binaries in the npm tarball while Node still runs as `x64`, which makes the server exit immediately.
+   - This package pins `onnxruntime-node` via `overrides` to a release that includes macOS x64 bindings. After `bun install` / `npm install`, you can confirm with: `bun run verify:native` (or `npm run verify:native`).
+
 **Getting Help:**
 - Check [Human MCP Issues](https://github.com/human-mcp/human-mcp/issues) 
 - Review client-specific MCP documentation  

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "marked": "^16.3.0",
         "mime-types": "^3.0.1",
         "multer": "^2.0.2",
+        "onnxruntime-node": "1.23.2",
         "playwright": "^1.56.0",
         "pptx-automizer": "^0.7.4",
         "rmbg": "^0.1.0",
@@ -49,6 +50,9 @@
         "typescript": "^5.6.0",
       },
     },
+  },
+  "overrides": {
+    "onnxruntime-node": "1.23.2",
   },
   "packages": {
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
@@ -1191,9 +1195,9 @@
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
-    "onnxruntime-common": ["onnxruntime-common@1.23.0", "", {}, "sha512-Auz8S9D7vpF8ok7fzTobvD1XdQDftRf/S7pHmjeCr3Xdymi4z1C7zx4vnT6nnUjbpelZdGwda0BmWHCCTMKUTg=="],
+    "onnxruntime-common": ["onnxruntime-common@1.23.2", "", {}, "sha512-5LFsC9Dukzp2WV6kNHYLNzp8sT6V02IubLCbzw2Xd6X5GOlr65gAX6xiJwyi2URJol/s71gaQLC5F2C25AAR2w=="],
 
-    "onnxruntime-node": ["onnxruntime-node@1.23.0", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.23.0" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-j7QVuR4ouektZjOopKtXcIGsB3C6R9kVbgS10lc2e5SxoWMUhmCwxNl4qBslpWJaPrFxvrQrQaQLQdqku8V19w=="],
+    "onnxruntime-node": ["onnxruntime-node@1.23.2", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.23.2" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-OBTsG0W8ddBVOeVVVychpVBS87A9YV5sa2hJ6lc025T97Le+J4v++PwSC4XFs1C62SWyNdof0Mh4KvnZgtt4aw=="],
 
     "option": ["option@0.2.4", "", {}, "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@goonnguyen/human-mcp",
-  "version": "2.14.0",
+  "version": "2.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@goonnguyen/human-mcp",
-      "version": "2.14.0",
+      "version": "2.15.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -28,6 +28,7 @@
         "marked": "^16.3.0",
         "mime-types": "^3.0.1",
         "multer": "^2.0.2",
+        "onnxruntime-node": "1.23.2",
         "playwright": "^1.56.0",
         "pptx-automizer": "^0.7.4",
         "rmbg": "^0.1.0",
@@ -2457,7 +2458,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -5121,7 +5121,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.2.tgz",
       "integrity": "sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -7301,7 +7300,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -8242,7 +8240,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
       "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12185,7 +12182,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12540,15 +12536,15 @@
       }
     },
     "node_modules/onnxruntime-common": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.2.tgz",
-      "integrity": "sha512-S0FFhJaI05jr1c3HVJ/DuPFB/aYdXmnUBuuQfuvLtcNn7WAfpm2ewSXn1vHs9Wa1l8T8OznhfCEdFv8qCn0/xw==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.23.2.tgz",
+      "integrity": "sha512-5LFsC9Dukzp2WV6kNHYLNzp8sT6V02IubLCbzw2Xd6X5GOlr65gAX6xiJwyi2URJol/s71gaQLC5F2C25AAR2w==",
       "license": "MIT"
     },
     "node_modules/onnxruntime-node": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.2.tgz",
-      "integrity": "sha512-ZtTkUHNNk+Xpi2Sq2BcFjzc9Vx4n3o5RxYLgRvdrFzCBsGUU1dQRFf4LM9tCc7vFhPSoZqbvzZtkzRMXoDqKNg==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.23.2.tgz",
+      "integrity": "sha512-OBTsG0W8ddBVOeVVVychpVBS87A9YV5sa2hJ6lc025T97Le+J4v++PwSC4XFs1C62SWyNdof0Mh4KvnZgtt4aw==",
       "hasInstallScript": true,
       "license": "MIT",
       "os": [
@@ -12559,7 +12555,7 @@
       "dependencies": {
         "adm-zip": "^0.5.16",
         "global-agent": "^3.0.0",
-        "onnxruntime-common": "1.24.2"
+        "onnxruntime-common": "1.23.2"
       }
     },
     "node_modules/option": {
@@ -13216,7 +13212,6 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13230,7 +13225,6 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -13717,7 +13711,6 @@
       "integrity": "sha512-phCkJ6pjDi9ANdhuF5ElS10GGdAKY6R1Pvt9lT3SFhOwM4T7QZE7MLpBDbNruUx/Q3gFD92/UOFringGipRqZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
@@ -13924,7 +13917,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -15240,7 +15232,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15479,7 +15470,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16238,7 +16228,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:parallel": "TEST_TYPE=all bun test 2>&1 | tee -a ./logs.txt",
     "test:safe": "TEST_TYPE=unit bun test tests/unit/ && TEST_TYPE=integration bun test tests/integration/sse-transport.test.ts && TEST_TYPE=integration bun test tests/integration/server.test.ts && TEST_TYPE=integration bun test tests/integration/http-transport-files.test.ts 2>&1 | tee -a ./logs.txt",
     "typecheck": "tsc --noEmit 2>&1 | tee -a ./logs.txt",
+    "verify:native": "node scripts/verify-onnxruntime.js",
     "inspector": "mcp-inspector stdio -- bun run src/index.ts 2>&1 | tee -a ./logs.txt"
   },
   "dependencies": {
@@ -40,6 +41,7 @@
     "marked": "^16.3.0",
     "mime-types": "^3.0.1",
     "multer": "^2.0.2",
+    "onnxruntime-node": "1.23.2",
     "playwright": "^1.56.0",
     "pptx-automizer": "^0.7.4",
     "rmbg": "^0.1.0",
@@ -48,6 +50,9 @@
     "wav": "^1.0.2",
     "xlsx": "^0.18.5",
     "zod": "^3.23.0"
+  },
+  "overrides": {
+    "onnxruntime-node": "1.23.2"
   },
   "devDependencies": {
     "@modelcontextprotocol/inspector": "^0.2.0",

--- a/scripts/verify-onnxruntime.js
+++ b/scripts/verify-onnxruntime.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Ensures onnxruntime-node (pulled in via rmbg) resolves to a build whose npm
+ * tarball includes native bindings for the current process.platform / process.arch.
+ *
+ * Some onnxruntime-node 1.24.x releases omitted darwin/x64 binaries from the
+ * published package while Node still reports arch=x64, causing startup crashes
+ * when background-removal tooling loads ONNX.
+ *
+ * Resolution: onnxruntime-node may be nested under `rmbg` rather than hoisted
+ * to the package root, so we resolve/load it from that dependency context.
+ */
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const rootRequire = createRequire(path.join(root, "package.json"));
+const rmbgRequire = createRequire(path.join(root, "node_modules/rmbg/package.json"));
+
+let pkgRoot;
+let loadOrt;
+
+try {
+  pkgRoot = path.dirname(rootRequire.resolve("onnxruntime-node/package.json"));
+  loadOrt = () => {
+    rootRequire("onnxruntime-node");
+  };
+} catch {
+  try {
+    pkgRoot = path.dirname(rmbgRequire.resolve("onnxruntime-node/package.json"));
+    loadOrt = () => {
+      rmbgRequire("onnxruntime-node");
+    };
+  } catch {
+    console.error(
+      "verify-onnxruntime: onnxruntime-node not found (expected via rmbg dependency)",
+    );
+    process.exit(1);
+  }
+}
+
+const binding = path.join(
+  pkgRoot,
+  "bin",
+  "napi-v6",
+  process.platform,
+  process.arch,
+  "onnxruntime_binding.node",
+);
+
+if (!fs.existsSync(binding)) {
+  console.error(`verify-onnxruntime: missing native binding at:\n  ${binding}`);
+  console.error(
+    "Install resolved to an onnxruntime-node version whose published tarball does not ship binaries for this OS/arch.",
+  );
+  process.exit(1);
+}
+
+try {
+  loadOrt();
+} catch (err) {
+  console.error(
+    "verify-onnxruntime: failed to load onnxruntime-node:",
+    err instanceof Error ? err.message : err,
+  );
+  process.exit(1);
+}
+
+console.log("verify-onnxruntime: OK");


### PR DESCRIPTION
## Summary
Pin `onnxruntime-node` to a version that ships `darwin/x64` native bindings so `human-mcp` does not crash on Intel Macs when background removal tooling loads ONNX.

## What changed
- Add `scripts/verify-onnxruntime.js` to assert the native binding exists and can be loaded for the current `process.platform`/`process.arch`.
- Pin `onnxruntime-node` to `1.23.2` via `overrides`.
- Add CI coverage by running `bun run verify:native` during PR builds.
- Update troubleshooting docs.

## Test plan
- `npm run verify:native`
- `npx bun@1.2.5 run typecheck`
- `npx bun@1.2.5 test tests/unit/`
- `npx bun@1.2.5 test tests/integration/`